### PR TITLE
Link organization-wide agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Repository Agent Guide
+
+Follow the [Durable Workflow organization-wide agent guide](https://github.com/durable-workflow/.github/blob/main/AGENTS.md).
+
+Repository-specific build and test commands live in this repository's README
+and contributing guide. The organization guide is authoritative for shared
+product, issue, security, conformance, and release rules.


### PR DESCRIPTION
Part of durable-workflow/.github#95.

Adds a root `AGENTS.md` pointer to the public organization-wide guide so a human or agent starting from this repository can discover the shared product, issue, security, conformance, and release rules. Existing repository-specific guidance is preserved.

Validation: `git diff --check`.