### PR TITLE
Release Waterline 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,18 @@
 
 ## Unreleased
 
-Waterline advances to the `2.0.0-rc.35` source identity. Deep-linked run-detail
+## 2.0.0 - 2026-09-01
+
+Waterline 2.0.0 is the stable operator UI for embedded and service-mode Durable
+Workflow deployments. Deep-linked run-detail
 sections remain pinned below persistent chrome through late browser scroll
 restoration and asynchronous service-mode layout settling, while direct user
 scrolling or keyboard navigation cancels that bounded positioning window.
 Repeated visual qualification now includes the populated service presentation
 at the mobile viewport that exposed the late fragment drift. Its package metadata
 now describes the operational UI across embedded and service-mode deployments.
-The standalone service distribution requires PHP SDK `2.0.0-rc.54`,
-while embedded integration targets Workflow `2.0.0-rc.53` without pulling the
+The standalone service distribution requires PHP SDK `2.0.0`,
+while embedded integration targets Workflow `2.0.1` without pulling the
 standalone SDK into the host application. Laravel-hosted service mode now
 checks for the optional SDK at its configuration boundary and reports the exact
 installation command when it is absent.

--- a/README.md
+++ b/README.md
@@ -27,18 +27,13 @@ This UI is installable via [Composer](https://getcomposer.org).
 
 ```bash
 composer require \
-    "durable-workflow/waterline:^2.0@RC" \
-    "durable-workflow/workflow:^2.0@RC"
+    "durable-workflow/waterline:^2.0" \
+    "durable-workflow/workflow:^2.0"
 
 php artisan waterline:install
 ```
 
-The `^2.0@RC` constraints follow the supported 2.0 prerelease channel without
-selecting an RC sequence number. Composer only honors prerelease stability
-allowances from the root project, so default-stable applications must allow
-both packages explicitly. The standalone PHP SDK is not part of the embedded
-dependency graph. Use a clean Composer solve when changing the channel, and
-drop the stability flags after `2.0.0` is tagged stable for both packages.
+The standalone PHP SDK is not part of the embedded dependency graph.
 
 ## Authorization
 
@@ -94,13 +89,13 @@ values in `effective_preferences` without mutating the stored preferences.
 
 ## Upgrading Waterline
 
-When upgrading into or within the 2.0 prerelease channel, let Composer resolve
-the supported channel together and publish the latest assets.
+When upgrading to 2.0, let Composer resolve the supported package graph together
+and publish the latest assets.
 
 ```bash
 composer require --with-all-dependencies \
-    "durable-workflow/waterline:^2.0@RC" \
-    "durable-workflow/workflow:^2.0@RC"
+    "durable-workflow/waterline:^2.0" \
+    "durable-workflow/workflow:^2.0"
 
 php artisan waterline:publish
 ```

--- a/SERVICE_MODE.md
+++ b/SERVICE_MODE.md
@@ -12,7 +12,7 @@ The host needs Docker, but does not need PHP, Laravel, Composer, or
 `durable-workflow/workflow`.
 
 ```bash
-WATERLINE_IMAGE="$(python3 scripts/resolve-current-prerelease.py image)"
+WATERLINE_IMAGE="durableworkflow/waterline:2.0.0"
 
 docker run --rm -p 8080:8080 \
   -v waterline-data:/data \
@@ -24,12 +24,8 @@ docker run --rm -p 8080:8080 \
   "$WATERLINE_IMAGE"
 ```
 
-Run the resolver from a Waterline `v2` checkout. It reads the public retained
-Waterline qualification, verifies the immutable qualification asset digest,
-and returns the qualified multi-platform image digest. The result is the
-reproducible qualified tuple, rather than a hand-maintained current tag. The
-resolver fails closed instead of selecting stable 1.x or an unqualified
-`latest` image.
+The exact `2.0.0` image keeps the deployment reproducible. Stable rolling tags
+are also published for users who deliberately opt into patch updates.
 
 Open `http://localhost:8080/waterline`. Bind the port to a private interface or
 put an authenticating reverse proxy in front of it when
@@ -122,10 +118,10 @@ registration summary without contributing rows or leases.
 [`deploy/docker-compose.service.yml`](deploy/docker-compose.service.yml) is a
 ready-to-edit service deployment. It keeps Waterline state in its own volume
 and accepts the standalone endpoint and token from the deployment environment.
-Resolve the qualified image before starting it:
+Select the stable image before starting it:
 
 ```bash
-WATERLINE_IMAGE="$(python3 scripts/resolve-current-prerelease.py image)" \
+WATERLINE_IMAGE="durableworkflow/waterline:2.0.0" \
   docker compose -f deploy/docker-compose.service.yml up -d
 ```
 
@@ -137,13 +133,13 @@ the PHP SDK, but not the embedded Workflow runtime:
 
 ```bash
 composer require \
-  "durable-workflow/waterline:^2.0@RC" \
-  "durable-workflow/sdk:^2.0@RC"
+  "durable-workflow/waterline:^2.0" \
+  "durable-workflow/sdk:^2.0"
 ```
 
 Set `WATERLINE_BACKEND=service` together with the endpoint, token, namespace,
 and access-mode inputs above. If service mode is selected without the SDK,
-Waterline stops during package boot and reports the prerelease-channel Composer
+Waterline stops during package boot and reports the stable-channel Composer
 command needed to add it.
 
 ## Embedded mode
@@ -153,8 +149,8 @@ the optional Workflow integration:
 
 ```bash
 composer require \
-  "durable-workflow/waterline:^2.0@RC" \
-  "durable-workflow/workflow:^2.0@RC"
+  "durable-workflow/waterline:^2.0" \
+  "durable-workflow/workflow:^2.0"
 
 php artisan waterline:install
 ```

--- a/app/Support/ServiceModeRequirements.php
+++ b/app/Support/ServiceModeRequirements.php
@@ -9,9 +9,9 @@ use LogicException;
 
 final class ServiceModeRequirements
 {
-    public const SDK_VERSION = '2.0.0-rc.54';
+    public const SDK_VERSION = '2.0.0';
 
-    public const SDK_ONBOARDING_CONSTRAINT = '^2.0@RC';
+    public const SDK_ONBOARDING_CONSTRAINT = '^2.0';
 
     /**
      * @param  (callable(class-string): bool)|null  $classExists

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "illuminate/support": "^9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
-        "durable-workflow/sdk": "2.0.0-rc.54",
-        "durable-workflow/workflow": "2.0.0-rc.53",
+        "durable-workflow/sdk": "2.0.0",
+        "durable-workflow/workflow": "2.0.1",
         "fakerphp/faker": "^1.9.1",
         "mockery/mockery": "^1.4.4",
         "orchestra/testbench": "^10.11",
@@ -73,7 +73,7 @@
     },
     "extra": {
         "durable-workflow": {
-            "product-train": "2.0.0-rc.35",
+            "product-train": "2.0.0",
             "service-capacity-evidence": {
                 "schema": "durable-workflow.v2.namespace-capacity-evidence",
                 "schema-version": 1,

--- a/deploy/docker-compose.service.yml
+++ b/deploy/docker-compose.service.yml
@@ -1,6 +1,6 @@
 services:
   waterline:
-    image: ${WATERLINE_IMAGE:?run-prerelease-resolver}
+    image: ${WATERLINE_IMAGE:?set-exact-waterline-image}
     restart: unless-stopped
     ports:
       - "127.0.0.1:${WATERLINE_PORT:-8080}:8080"

--- a/release/current-product-tuple.json
+++ b/release/current-product-tuple.json
@@ -1,8 +1,8 @@
 {
     "schema": "durable-workflow.waterline-current-product-tuple/v1",
     "versions": {
-        "waterline": "2.0.0-rc.34",
-        "workflow": "2.0.0-rc.53",
-        "sdk-php": "2.0.0-rc.54"
+        "waterline": "2.0.0-rc.35",
+        "workflow": "2.0.1",
+        "sdk-php": "2.0.0"
     }
 }

--- a/scripts/ci/check-onboarding-composer.sh
+++ b/scripts/ci/check-onboarding-composer.sh
@@ -77,11 +77,13 @@ from pathlib import Path
 
 authority_path, embedded_path, service_path = map(Path, sys.argv[1:])
 release_authority = authority_path.read_text(encoding="utf-8").split()
-pattern = re.compile(r"^2\.0\.0-rc\.[1-9][0-9]*$")
+version_pattern = re.compile(
+    r"^2\.0\.(?:0|[1-9][0-9]*)(?:-rc\.[1-9][0-9]*)?$"
+)
 commit_pattern = re.compile(r"^[0-9a-f]{40}$")
 if release_authority and (
     len(release_authority) != 2
-    or pattern.fullmatch(release_authority[0]) is None
+    or version_pattern.fullmatch(release_authority[0]) is None
     or commit_pattern.fullmatch(release_authority[1]) is None
 ):
     raise SystemExit("current public Waterline release authority is malformed")
@@ -108,8 +110,8 @@ for graph, path in (("embedded", embedded_path), ("service", service_path)):
     }
     if set(packages) != expected[graph]:
         raise SystemExit(f"{graph} onboarding graph did not resolve both roots")
-    if any(pattern.fullmatch(version) is None for version in packages.values()):
-        raise SystemExit(f"{graph} onboarding graph escaped the 2.0 RC channel")
+    if any(version_pattern.fullmatch(version) is None for version in packages.values()):
+        raise SystemExit(f"{graph} onboarding graph escaped the supported 2.0 line")
     if (
         qualified_waterline is not None
         and packages["durable-workflow/waterline"] != qualified_waterline
@@ -133,7 +135,8 @@ evidence = {
         if qualified_source_commit is not None
         else "registry-graph-consensus"
     ),
-    "channel": "^2.0@RC",
+    "channel": "2.0",
+    "composer_constraint": "^2.0@RC",
     "qualified_waterline": qualified_waterline,
     "graphs": resolved,
     "outcome": "pass",

--- a/scripts/ci/release_example_contract.py
+++ b/scripts/ci/release_example_contract.py
@@ -18,8 +18,8 @@ WATERLINE_PACKAGE = "durable-workflow/waterline"
 WORKFLOW_PACKAGE = "durable-workflow/workflow"
 SDK_PACKAGE = "durable-workflow/sdk"
 SERVICE_IMAGE = "durableworkflow/waterline"
-ONBOARDING_CONSTRAINT = "^2.0@RC"
-PRERELEASE_RESOLVER = "scripts/resolve-current-prerelease.py"
+ONBOARDING_CONSTRAINT = "^2.0"
+STABLE_IMAGE = f"{SERVICE_IMAGE}:2.0.0"
 EXACT_VERSION = re.compile(
     r"^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z]+(?:\.[0-9A-Za-z]+)*)?$"
 )
@@ -316,8 +316,8 @@ def validate_documented_images(
             for token in tokens
         ):
             raise ContractError(
-                f"{source} copies a service image reference; use the "
-                f"machine-owned {PRERELEASE_RESOLVER} output"
+                f"{source} copies a service image reference directly; assign "
+                "the exact stable image to WATERLINE_IMAGE"
             )
 
     if resolved < minimum:
@@ -325,14 +325,17 @@ def validate_documented_images(
             f"{source} must contain at least {minimum} Docker example using "
             "$WATERLINE_IMAGE"
         )
-    resolver_commands = [
+    image_assignments = [
         command
         for command in shell_commands(document)
-        if PRERELEASE_RESOLVER in command and command.endswith(' image)"')
+        if command in {
+            f'WATERLINE_IMAGE="{STABLE_IMAGE}"',
+            f"WATERLINE_IMAGE={STABLE_IMAGE}",
+        }
     ]
-    if not resolver_commands:
+    if not image_assignments:
         raise ContractError(
-            f"{source} must obtain WATERLINE_IMAGE from {PRERELEASE_RESOLVER}"
+            f"{source} must assign WATERLINE_IMAGE to {STABLE_IMAGE}"
         )
     return resolved
 

--- a/scripts/ci/test-release-example-contract.py
+++ b/scripts/ci/test-release-example-contract.py
@@ -30,9 +30,9 @@ contract = load_contract()
 
 
 RELEASE = contract.ReleaseTuple(
-    waterline="2.0.0-rc.91",
-    workflow="2.0.0-rc.120",
-    sdk="2.0.0-rc.63",
+    waterline="2.0.0",
+    workflow="2.0.1",
+    sdk="2.0.2",
 )
 
 
@@ -136,10 +136,10 @@ The install command can move and use indented Markdown instead.
                 minimum=1,
             )
 
-    def test_accepts_resolver_backed_image_without_prose_coupling(self) -> None:
+    def test_accepts_exact_stable_image_without_prose_coupling(self) -> None:
         document = f"""
 ```bash
-WATERLINE_IMAGE="$(python3 {contract.PRERELEASE_RESOLVER} image)"
+WATERLINE_IMAGE="{contract.STABLE_IMAGE}"
 docker run --rm "$WATERLINE_IMAGE"
 ```
 
@@ -181,15 +181,15 @@ Retained compatibility evidence names
                 f"services:\n  waterline:\n    image: {contract.SERVICE_IMAGE}:latest\n",
             )
 
-    def test_accepts_compose_image_required_from_resolver(self) -> None:
+    def test_accepts_compose_image_required_from_release_input(self) -> None:
         compose = (
             "services:\n"
             "  waterline:\n"
-            "    image: ${WATERLINE_IMAGE:?run-prerelease-resolver}\n"
+            "    image: ${WATERLINE_IMAGE:?set-exact-waterline-image}\n"
         )
 
         self.assertEqual(
-            "${WATERLINE_IMAGE:?run-prerelease-resolver}",
+            "${WATERLINE_IMAGE:?set-exact-waterline-image}",
             contract.validate_default_image(
                 "deploy/docker-compose.service.yml",
                 compose,

--- a/scripts/ci/test-waterline-release-identity.py
+++ b/scripts/ci/test-waterline-release-identity.py
@@ -22,11 +22,11 @@ SPEC.loader.exec_module(identity)
 
 
 CURRENT_PUBLIC = {
-    "waterline": "2.0.0-rc.34",
-    "workflow": "2.0.0-rc.53",
-    "sdk-php": "2.0.0-rc.54",
+    "waterline": "2.0.0-rc.35",
+    "workflow": "2.0.1",
+    "sdk-php": "2.0.0",
 }
-CANDIDATE_WATERLINE = "2.0.0-rc.35"
+CANDIDATE_WATERLINE = "2.0.0"
 PUBLIC_SDK_REFERENCE = "0123456789abcdef0123456789abcdef01234567"
 
 
@@ -190,6 +190,13 @@ class WaterlineReleaseIdentityTest(unittest.TestCase):
 
         with self.assertRaisesRegex(identity.IdentityError, "does not match source-declared"):
             validate(release_version="2.0.0-rc.14")
+
+    def test_release_identity_rejects_versions_outside_the_supported_2_0_line(self) -> None:
+        unsupported = manifest()
+        unsupported["extra"]["durable-workflow"]["product-train"] = "2.1.0"
+
+        with self.assertRaisesRegex(identity.IdentityError, "exact supported 2.0 release"):
+            validate(candidate_manifest=unsupported)
 
     def test_every_branch_route_runs_current_identity_qualification(self) -> None:
         document = workflow("php.yml")

--- a/scripts/ci/waterline_release_identity.py
+++ b/scripts/ci/waterline_release_identity.py
@@ -16,7 +16,9 @@ SCHEMA = "durable-workflow.waterline-current-product-tuple/v1"
 PACKAGE = "durable-workflow/waterline"
 SDK_PACKAGE = "durable-workflow/sdk"
 WORKFLOW_PACKAGE = "durable-workflow/workflow"
-PRERELEASE = re.compile(r"^2\.0\.0-(?:alpha|beta|rc)\.[1-9][0-9]*$")
+SUPPORTED_2_0 = re.compile(
+    r"^2\.0\.(?:0|[1-9][0-9]*)(?:-(?:alpha|beta|rc)\.[1-9][0-9]*)?$"
+)
 PUBLIC_COMMIT = re.compile(r"^[0-9a-f]{40}$")
 
 
@@ -36,8 +38,8 @@ def load_json(path: Path, label: str) -> tuple[dict[str, Any], bytes]:
 
 
 def exact_version(value: object, label: str) -> str:
-    if not isinstance(value, str) or PRERELEASE.fullmatch(value) is None:
-        raise IdentityError(f"{label} must be an exact supported 2.0 prerelease")
+    if not isinstance(value, str) or SUPPORTED_2_0.fullmatch(value) is None:
+        raise IdentityError(f"{label} must be an exact supported 2.0 release")
     return value
 
 

--- a/standalone/composer.json
+++ b/standalone/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.3",
-        "durable-workflow/sdk": "2.0.0-rc.54",
+        "durable-workflow/sdk": "2.0.0",
         "laravel/framework": "^12.0"
     },
     "autoload": {

--- a/standalone/composer.lock
+++ b/standalone/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dbf3a560fdb9199e4cadd6bba3f747bc",
+    "content-hash": "430a63c2f7f02bc615d9d26df6874815",
     "packages": [
         {
             "name": "apache/avro",
@@ -505,16 +505,16 @@
         },
         {
             "name": "durable-workflow/sdk",
-            "version": "2.0.0-rc.54",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/durable-workflow/sdk-php.git",
-                "reference": "29a60cabf5e185d5735e9a34a1d2c09560cedd6f"
+                "reference": "af7931e79683adf55bfa87cd7b3b90561bc137cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/durable-workflow/sdk-php/zipball/29a60cabf5e185d5735e9a34a1d2c09560cedd6f",
-                "reference": "29a60cabf5e185d5735e9a34a1d2c09560cedd6f",
+                "url": "https://api.github.com/repos/durable-workflow/sdk-php/zipball/af7931e79683adf55bfa87cd7b3b90561bc137cf",
+                "reference": "af7931e79683adf55bfa87cd7b3b90561bc137cf",
                 "shasum": ""
             },
             "require": {
@@ -555,7 +555,7 @@
                         "laravel": "^9.0|^10.0|^11.0|^12.0|^13.0",
                         "symfony": "^6.4|^7.0|^8.0"
                     },
-                    "product-train": "2.0.0-rc.54",
+                    "product-train": "2.0.0",
                     "payload-codecs": [
                         "avro"
                     ],
@@ -583,7 +583,7 @@
                         "deprecatePatch"
                     ],
                     "worker-protocol-version": "1.19",
-                    "supported-server-versions": "2.0.0-rc.68",
+                    "supported-server-versions": "2.0.0",
                     "version-marker-history-event": "VersionMarkerRecorded",
                     "message-streams-minimum-worker-protocol-version": "1.15",
                     "durable-selection-minimum-worker-protocol-version": "1.19"
@@ -617,7 +617,7 @@
                 "issues": "https://github.com/durable-workflow/sdk-php/issues",
                 "source": "https://github.com/durable-workflow/sdk-php"
             },
-            "time": "2026-08-31T03:39:19+00:00"
+            "time": "2026-09-01T01:00:27+00:00"
         },
         {
             "name": "egulias/email-validator",
@@ -6001,9 +6001,7 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "durable-workflow/sdk": 5
-    },
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/tests/Unit/InstallationContractTest.php
+++ b/tests/Unit/InstallationContractTest.php
@@ -47,7 +47,7 @@ final class InstallationContractTest extends TestCase
         $sdkVersion = $published['versions']['sdk-php'] ?? null;
         $workflowVersion = $published['versions']['workflow'] ?? null;
 
-        $this->assertSame('2.0.0-rc.35', $releaseVersion);
+        $this->assertSame('2.0.0', $releaseVersion);
         $this->assertSame([
             'server' => '2.0.0-rc.32',
             'sdk-php' => '2.0.0-rc.14',

--- a/tests/Unit/ServiceModeRequirementsTest.php
+++ b/tests/Unit/ServiceModeRequirementsTest.php
@@ -20,7 +20,7 @@ final class ServiceModeRequirementsTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    public function testServiceModeReportsPrereleaseChannelRemediationWhenThePhpSdkIsMissing(): void
+    public function testServiceModeReportsStableChannelRemediationWhenThePhpSdkIsMissing(): void
     {
         try {
             ServiceModeRequirements::assertSdkInstalled(static fn (string $class): bool => false);
@@ -29,7 +29,7 @@ final class ServiceModeRequirementsTest extends TestCase
             $message = $exception->getMessage();
 
             $this->assertStringContainsString(
-                'composer require --with-all-dependencies "durable-workflow/sdk:^2.0@RC"',
+                'composer require --with-all-dependencies "durable-workflow/sdk:^2.0"',
                 $message,
             );
             $this->assertDoesNotMatchRegularExpression(
@@ -39,16 +39,16 @@ final class ServiceModeRequirementsTest extends TestCase
         }
     }
 
-    public function testServiceModeRejectsAnOlderPrereleaseWithoutACompatibilityShim(): void
+    public function testServiceModeRejectsAnOlderReleaseWithoutACompatibilityShim(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage(
-            'Waterline service mode requires durable-workflow/sdk 2.0.0-rc.54 exactly; installed 2.0.0-rc.40.',
+            'Waterline service mode requires durable-workflow/sdk 2.0.0 exactly; installed 2.0.0-rc.54.',
         );
 
         ServiceModeRequirements::assertSdkInstalled(
             static fn (string $class): bool => true,
-            static fn (): string => '2.0.0-rc.40',
+            static fn (): string => '2.0.0-rc.54',
         );
     }
 }

--- a/tests/Unit/WorkerStatusConformanceRunnerTest.php
+++ b/tests/Unit/WorkerStatusConformanceRunnerTest.php
@@ -573,9 +573,9 @@ REGEX,
         $runner = (string) file_get_contents($root.'/app/Console/WorkerStatusConformanceCommand.php');
         $worker = (string) file_get_contents($root.'/app/Console/WorkerStatusSdkWorkerCommand.php');
 
-        $this->assertSame('2.0.0-rc.35', $manifest['extra']['durable-workflow']['product-train'] ?? null);
-        $this->assertSame('2.0.0-rc.53', $manifest['require-dev']['durable-workflow/workflow'] ?? null);
-        $this->assertSame('2.0.0-rc.54', $manifest['require-dev']['durable-workflow/sdk'] ?? null);
+        $this->assertSame('2.0.0', $manifest['extra']['durable-workflow']['product-train'] ?? null);
+        $this->assertSame('2.0.1', $manifest['require-dev']['durable-workflow/workflow'] ?? null);
+        $this->assertSame('2.0.0', $manifest['require-dev']['durable-workflow/sdk'] ?? null);
         $this->assertStringContainsString('use DurableWorkflow\\Client as SdkClient;', $runner);
         $this->assertStringContainsString('use DurableWorkflow\\SdkIdentity;', $runner);
         $this->assertStringContainsString('SdkIdentity::registration()', $runner);


### PR DESCRIPTION
Publishes the stable Waterline 2.0 source for embedded and service-mode operation.

- pins the public PHP SDK 2.0.0 release in the standalone distribution
- qualifies embedded integration against Workflow 2.0.1
- records the stable 2.0.0 package and service-image identity
- removes prerelease wording from release-facing setup material

Validated locally with the exact public Composer dependencies, release identity tests (10/10), installation contracts (5/5, 23 assertions), Composer validation, and the public-boundary scan.