### PR TITLE
Finish Waterline 1.x branch migration

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,9 +2,9 @@ name: build
 
 on:
   push:
-    branches: [ master, '1.x' ]
+    branches: ['1.x']
   pull_request:
-    branches: [ master, '1.x' ]
+    branches: ['1.x']
 
 jobs:
   build:


### PR DESCRIPTION
Removes the temporary `master` compatibility trigger now that the legacy maintenance branch has been renamed to `1.x`. The branch tip, package history, and release tags remain unchanged.

Part of #99.