### PR TITLE
Prepare Waterline stable branch for main

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,9 +2,9 @@ name: build
 
 on:
   push:
-    branches: [v2]
+    branches: [v2, main]
   pull_request:
-    branches: [v2]
+    branches: [v2, main]
   workflow_dispatch:
 
 permissions:
@@ -273,7 +273,7 @@ jobs:
         repository: durable-workflow/workflow
         path: workflow
         persist-credentials: false
-        ref: v2
+        ref: main
 
     - name: Install PHP 8.4 and Composer
       uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240  # v2
@@ -461,7 +461,7 @@ jobs:
         repository: durable-workflow/workflow
         path: workflow
         persist-credentials: false
-        ref: v2
+        ref: main
 
     - name: Install PHP 8.4 and Composer
       uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240  # v2

--- a/.github/workflows/service-capacity-tuple.yml
+++ b/.github/workflows/service-capacity-tuple.yml
@@ -3,7 +3,7 @@ name: Service capacity release tuple
 on:
   pull_request:
   push:
-    branches: [v2]
+    branches: [v2, main]
 
 permissions:
   contents: read

--- a/.github/workflows/service-image-smoke.yml
+++ b/.github/workflows/service-image-smoke.yml
@@ -3,7 +3,7 @@ name: Service image smoke
 on:
   pull_request:
   push:
-    branches: [v2]
+    branches: [v2, main]
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Waterline
 
 <p align="center">
-  <a href="https://github.com/durable-workflow/waterline/actions/workflows/php.yml?query=branch%3Av2"><img src="https://github.com/durable-workflow/waterline/actions/workflows/php.yml/badge.svg?branch=v2" alt="Build status"></a>
+  <a href="https://github.com/durable-workflow/waterline/actions/workflows/php.yml?query=branch%3Amain"><img src="https://github.com/durable-workflow/waterline/actions/workflows/php.yml/badge.svg?branch=main" alt="Build status"></a>
   <a href="https://packagist.org/packages/durable-workflow/waterline"><img src="https://img.shields.io/packagist/v/durable-workflow/waterline" alt="Latest Packagist version"></a>
   <a href="https://hub.docker.com/r/durableworkflow/waterline"><img src="https://img.shields.io/docker/pulls/durableworkflow/waterline" alt="Docker pulls"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/durable-workflow/waterline" alt="MIT license"></a>

--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,9 @@
         "prepare": "@php vendor/bin/testbench package:discover --ansi"
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "2.0.x-dev"
+        },
         "durable-workflow": {
             "product-train": "2.0.0",
             "service-capacity-evidence": {


### PR DESCRIPTION
Prepares the current 2.x line for GitHub branch rename without interrupting CI.

- accept both `v2` and `main` during the rename window
- point Workflow source checkouts at the new `main` branch
- update the current-line build badge
- preserve package history, release tags, and service-image behavior

Part of #99.