### PR TITLE
Finish Waterline main branch migration

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,9 +2,9 @@ name: build
 
 on:
   push:
-    branches: [v2, main]
+    branches: [main]
   pull_request:
-    branches: [v2, main]
+    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/service-capacity-tuple.yml
+++ b/.github/workflows/service-capacity-tuple.yml
@@ -3,7 +3,7 @@ name: Service capacity release tuple
 on:
   pull_request:
   push:
-    branches: [v2, main]
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/service-image-smoke.yml
+++ b/.github/workflows/service-image-smoke.yml
@@ -3,7 +3,7 @@ name: Service image smoke
 on:
   pull_request:
   push:
-    branches: [v2, main]
+    branches: [main]
 
 permissions:
   contents: read

--- a/scripts/ci/workflow_trust_policy.py
+++ b/scripts/ci/workflow_trust_policy.py
@@ -117,10 +117,10 @@ def validate_focused_workflow(
             ):
                 violations.add(Violation(workflow_name, "filtered-focused-trigger"))
             branches = trigger_configuration.get("branches")
-            if isinstance(branches, str) and branches != "v2":
-                violations.add(Violation(workflow_name, "focused-trigger-misses-v2"))
-            if isinstance(branches, list) and "v2" not in branches:
-                violations.add(Violation(workflow_name, "focused-trigger-misses-v2"))
+            if isinstance(branches, str) and branches != "main":
+                violations.add(Violation(workflow_name, "focused-trigger-misses-main"))
+            if isinstance(branches, list) and "main" not in branches:
+                violations.add(Violation(workflow_name, "focused-trigger-misses-main"))
 
     command = str(contract["command"])
     jobs = document.get("jobs", {})


### PR DESCRIPTION
Removes the temporary `v2` CI trigger entries now that `main` is the stable default branch.

The branch rename, protection, and ruleset migration are already complete. This PR changes only branch trigger filters.