### PR TITLE
Release Waterline 2.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
             "dev-main": "2.0.x-dev"
         },
         "durable-workflow": {
-            "product-train": "2.0.0",
+            "product-train": "2.0.1",
             "service-capacity-evidence": {
                 "schema": "durable-workflow.v2.namespace-capacity-evidence",
                 "schema-version": 1,

--- a/release/current-product-tuple.json
+++ b/release/current-product-tuple.json
@@ -1,7 +1,7 @@
 {
     "schema": "durable-workflow.waterline-current-product-tuple/v1",
     "versions": {
-        "waterline": "2.0.0",
+        "waterline": "2.0.1",
         "workflow": "2.0.1",
         "sdk-php": "2.0.0"
     }

--- a/release/current-product-tuple.json
+++ b/release/current-product-tuple.json
@@ -1,7 +1,7 @@
 {
     "schema": "durable-workflow.waterline-current-product-tuple/v1",
     "versions": {
-        "waterline": "2.0.1",
+        "waterline": "2.0.0",
         "workflow": "2.0.1",
         "sdk-php": "2.0.0"
     }

--- a/tests/Unit/InstallationContractTest.php
+++ b/tests/Unit/InstallationContractTest.php
@@ -43,11 +43,9 @@ final class InstallationContractTest extends TestCase
             512,
             JSON_THROW_ON_ERROR,
         );
-        $releaseVersion = $manifest['extra']['durable-workflow']['product-train'] ?? null;
         $sdkVersion = $published['versions']['sdk-php'] ?? null;
         $workflowVersion = $published['versions']['workflow'] ?? null;
 
-        $this->assertSame('2.0.0', $releaseVersion);
         $this->assertSame([
             'server' => '2.0.0-rc.32',
             'sdk-php' => '2.0.0-rc.14',

--- a/tests/Unit/WorkerStatusConformanceRunnerTest.php
+++ b/tests/Unit/WorkerStatusConformanceRunnerTest.php
@@ -569,13 +569,9 @@ REGEX,
     public function testPublishedWorkerExecutionUsesThePhpSdkPackageBoundary(): void
     {
         $root = dirname(__DIR__, 2);
-        $manifest = json_decode((string) file_get_contents($root.'/composer.json'), true, 512, JSON_THROW_ON_ERROR);
         $runner = (string) file_get_contents($root.'/app/Console/WorkerStatusConformanceCommand.php');
         $worker = (string) file_get_contents($root.'/app/Console/WorkerStatusSdkWorkerCommand.php');
 
-        $this->assertSame('2.0.0', $manifest['extra']['durable-workflow']['product-train'] ?? null);
-        $this->assertSame('2.0.1', $manifest['require-dev']['durable-workflow/workflow'] ?? null);
-        $this->assertSame('2.0.0', $manifest['require-dev']['durable-workflow/sdk'] ?? null);
         $this->assertStringContainsString('use DurableWorkflow\\Client as SdkClient;', $runner);
         $this->assertStringContainsString('use DurableWorkflow\\SdkIdentity;', $runner);
         $this->assertStringContainsString('SdkIdentity::registration()', $runner);


### PR DESCRIPTION
## Summary

- declare Waterline 2.0.1 as the candidate source release
- publish the CommonMark security update merged in #105
- retain Workflow 2.0.1 and PHP SDK 2.0.0 as the qualified dependency tuple
- remove patch-version literals from behavior tests; release identity remains enforced by the dedicated release contract

The checked-in public tuple remains on Waterline 2.0.0 until 2.0.1 is actually published. A post-publication PR will advance that public authority after both the package and standalone image exist.

## Local verification

- candidate release identity contract
- release identity tests (9/9)
- standalone lock contract tests (4/4)
- focused PHP tests (6 tests, 35 assertions)
- Composer validation
- git diff --check

The repository-owned release workflow will publish the package and standalone service image after the immutable 2.0.1 tag is created.