### PR TITLE
Advance published Waterline tuple to 2.0.1

### DIFF
--- a/release/current-product-tuple.json
+++ b/release/current-product-tuple.json
@@ -1,7 +1,7 @@
 {
     "schema": "durable-workflow.waterline-current-product-tuple/v1",
     "versions": {
-        "waterline": "2.0.0",
+        "waterline": "2.0.1",
         "workflow": "2.0.1",
         "sdk-php": "2.0.0"
     }


### PR DESCRIPTION
## Summary

Advance the checked-in public Waterline authority after publication completed.

## Verified public artifacts

- Packagist resolves durable-workflow/waterline 2.0.1 to bfb89d767f31ed7bb2357a731ad6584bfc0a1bc0
- Docker Hub exposes linux/amd64 and linux/arm64 manifests for durableworkflow/waterline:2.0.1
- the repository release workflow built, published, and smoked the exact image
- clean embedded and service Composer onboarding graphs resolve Waterline 2.0.1
- GitHub release: https://github.com/durable-workflow/waterline/releases/tag/2.0.1