### PR TITLE
Accept compatible PHP SDK 2.x releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 2.0.2 - 2026-09-03
+
+Waterline service mode now treats stable PHP SDK `2.x` releases as the
+SemVer-compatible line instead of requiring exact patch lockstep. The package
+and standalone service are qualified against PHP SDK `2.0.1`; prerelease and
+incompatible major versions still fail at startup with actionable guidance.
+
 ## 2.0.0 - 2026-09-01
 
 Waterline 2.0.0 is the stable operator UI for embedded and service-mode Durable

--- a/app/Support/ServiceModeRequirements.php
+++ b/app/Support/ServiceModeRequirements.php
@@ -9,7 +9,7 @@ use LogicException;
 
 final class ServiceModeRequirements
 {
-    public const SDK_VERSION = '2.0.0';
+    public const SDK_QUALIFIED_VERSION = '2.0.1';
 
     public const SDK_ONBOARDING_CONSTRAINT = '^2.0';
 
@@ -32,12 +32,18 @@ final class ServiceModeRequirements
 
         $installedVersion ??= static fn (): ?string => InstalledVersions::getPrettyVersion('durable-workflow/sdk');
         $actual = $installedVersion();
-        if ($actual !== self::SDK_VERSION) {
+        if (! self::supportsSdkVersion($actual)) {
             throw new LogicException(sprintf(
-                'Waterline service mode requires durable-workflow/sdk %s exactly; installed %s. Update the SDK before starting Waterline service mode.',
-                self::SDK_VERSION,
+                'Waterline service mode requires a stable durable-workflow/sdk release matching %s; installed %s. Update the SDK before starting Waterline service mode.',
+                self::SDK_ONBOARDING_CONSTRAINT,
                 $actual ?? '<unknown>',
             ));
         }
+    }
+
+    private static function supportsSdkVersion(?string $version): bool
+    {
+        return is_string($version)
+            && preg_match('/\A2\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\z/D', $version) === 1;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "illuminate/support": "^9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
-        "durable-workflow/sdk": "2.0.0",
+        "durable-workflow/sdk": "2.0.1",
         "durable-workflow/workflow": "2.0.1",
         "fakerphp/faker": "^1.9.1",
         "mockery/mockery": "^1.4.4",
@@ -76,7 +76,7 @@
             "dev-main": "2.0.x-dev"
         },
         "durable-workflow": {
-            "product-train": "2.0.1",
+            "product-train": "2.0.2",
             "service-capacity-evidence": {
                 "schema": "durable-workflow.v2.namespace-capacity-evidence",
                 "schema-version": 1,

--- a/scripts/ci/test-waterline-release-identity.py
+++ b/scripts/ci/test-waterline-release-identity.py
@@ -22,11 +22,12 @@ SPEC.loader.exec_module(identity)
 
 
 CURRENT_PUBLIC = {
-    "waterline": "2.0.0-rc.35",
+    "waterline": "2.0.1",
     "workflow": "2.0.1",
     "sdk-php": "2.0.0",
 }
-CANDIDATE_WATERLINE = "2.0.0"
+CANDIDATE_WATERLINE = "2.0.2"
+CANDIDATE_SDK = "2.0.1"
 PUBLIC_SDK_REFERENCE = "0123456789abcdef0123456789abcdef01234567"
 
 
@@ -39,7 +40,7 @@ def manifest() -> dict:
         "name": identity.PACKAGE,
         "require": {},
         "require-dev": {
-            identity.SDK_PACKAGE: CURRENT_PUBLIC["sdk-php"],
+            identity.SDK_PACKAGE: CANDIDATE_SDK,
             identity.WORKFLOW_PACKAGE: CURRENT_PUBLIC["workflow"],
         },
         "extra": {"durable-workflow": {"product-train": CANDIDATE_WATERLINE}},
@@ -47,11 +48,11 @@ def manifest() -> dict:
 
 
 def standalone() -> dict:
-    return {"require": {identity.SDK_PACKAGE: CURRENT_PUBLIC["sdk-php"]}}
+    return {"require": {identity.SDK_PACKAGE: CANDIDATE_SDK}}
 
 
 def lock() -> dict:
-    version = CURRENT_PUBLIC["sdk-php"]
+    version = CANDIDATE_SDK
     return {
         "packages": [
             {
@@ -115,7 +116,7 @@ class WaterlineReleaseIdentityTest(unittest.TestCase):
             {
                 "waterline": CANDIDATE_WATERLINE,
                 "workflow": CURRENT_PUBLIC["workflow"],
-                "sdk-php": CURRENT_PUBLIC["sdk-php"],
+                "sdk-php": CANDIDATE_SDK,
             },
             evidence["candidate_source"],
         )
@@ -126,7 +127,7 @@ class WaterlineReleaseIdentityTest(unittest.TestCase):
         stale["require-dev"][identity.SDK_PACKAGE] = "2.0.0-rc.11"
 
         with self.assertRaisesRegex(
-            identity.IdentityError, "do not match the current public dependency selection"
+            identity.IdentityError, "precedes the current public dependency"
         ):
             validate(candidate_manifest=stale)
 
@@ -135,7 +136,7 @@ class WaterlineReleaseIdentityTest(unittest.TestCase):
         stale["require-dev"][identity.WORKFLOW_PACKAGE] = "2.0.0-rc.13"
 
         with self.assertRaisesRegex(
-            identity.IdentityError, "do not match the current public dependency selection"
+            identity.IdentityError, "precedes the current public dependency"
         ):
             validate(candidate_manifest=stale)
 

--- a/scripts/ci/waterline_release_identity.py
+++ b/scripts/ci/waterline_release_identity.py
@@ -17,7 +17,7 @@ PACKAGE = "durable-workflow/waterline"
 SDK_PACKAGE = "durable-workflow/sdk"
 WORKFLOW_PACKAGE = "durable-workflow/workflow"
 SUPPORTED_2_0 = re.compile(
-    r"^2\.0\.(?:0|[1-9][0-9]*)(?:-(?:alpha|beta|rc)\.[1-9][0-9]*)?$"
+    r"^2\.0\.(?P<patch>0|[1-9][0-9]*)(?:-(?P<stage>alpha|beta|rc)\.(?P<number>[1-9][0-9]*))?$"
 )
 PUBLIC_COMMIT = re.compile(r"^[0-9a-f]{40}$")
 
@@ -41,6 +41,19 @@ def exact_version(value: object, label: str) -> str:
     if not isinstance(value, str) or SUPPORTED_2_0.fullmatch(value) is None:
         raise IdentityError(f"{label} must be an exact supported 2.0 release")
     return value
+
+
+def version_order(value: str) -> tuple[int, int, int]:
+    match = SUPPORTED_2_0.fullmatch(value)
+    if match is None:
+        raise IdentityError(f"cannot order unsupported release {value!r}")
+    stage = match.group("stage")
+    stage_order = {"alpha": 0, "beta": 1, "rc": 2, None: 3}
+    return (
+        int(match.group("patch")),
+        stage_order[stage],
+        int(match.group("number") or 0),
+    )
 
 
 def approved_versions(approved: Mapping[str, Any]) -> dict[str, str]:
@@ -154,32 +167,26 @@ def validate(
             manifest, "require-dev", SDK_PACKAGE, "release source composer.json"
         ),
     }
-    candidate_dependencies = {
-        name: candidate[name] for name in ("workflow", "sdk-php")
-    }
-    published_dependencies = {
-        name: published[name] for name in ("workflow", "sdk-php")
-    }
-    if candidate_dependencies != published_dependencies:
-        raise IdentityError(
-            "candidate source dependency pins do not match the current public "
-            f"dependency selection: expected {published_dependencies}, "
-            f"observed {candidate_dependencies}"
-        )
+    for name in ("workflow", "sdk-php"):
+        if version_order(candidate[name]) < version_order(published[name]):
+            raise IdentityError(
+                f"candidate source {name} dependency {candidate[name]} precedes "
+                f"the current public dependency {published[name]}"
+            )
 
     standalone_sdk = required_version(
         standalone, "require", SDK_PACKAGE, "standalone/composer.json"
     )
-    if standalone_sdk != published["sdk-php"]:
+    if standalone_sdk != candidate["sdk-php"]:
         raise IdentityError(
-            "standalone service PHP SDK identity does not match the current public "
-            "dependency selection"
+            "standalone service PHP SDK identity does not match the candidate "
+            "source dependency selection"
         )
     locked_sdk = locked_version(lock, SDK_PACKAGE)
-    if locked_sdk != published["sdk-php"]:
+    if locked_sdk != candidate["sdk-php"]:
         raise IdentityError(
-            "standalone service lock PHP SDK identity does not match the current "
-            "public dependency selection"
+            "standalone service lock PHP SDK identity does not match the candidate "
+            "source dependency selection"
         )
     require_locked_public_route(lock, SDK_PACKAGE)
 
@@ -244,9 +251,10 @@ def main(arguments: Sequence[str] | None = None) -> int:
         else f"candidate Waterline source {candidate['waterline']}"
     )
     print(
-        f"Verified {subject} with current public dependencies Workflow "
-        f"{published['workflow']} and PHP SDK {published['sdk-php']}; current "
-        f"published Waterline is {published['waterline']}"
+        f"Verified {subject} with candidate dependencies Workflow "
+        f"{candidate['workflow']} and PHP SDK {candidate['sdk-php']}; current "
+        f"public tuple is Waterline {published['waterline']}, Workflow "
+        f"{published['workflow']}, and PHP SDK {published['sdk-php']}"
     )
     return 0
 

--- a/standalone/composer.json
+++ b/standalone/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.3",
-        "durable-workflow/sdk": "2.0.0",
+        "durable-workflow/sdk": "2.0.1",
         "laravel/framework": "^12.0"
     },
     "autoload": {

--- a/standalone/composer.lock
+++ b/standalone/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "430a63c2f7f02bc615d9d26df6874815",
+    "content-hash": "72e5cd599d32815fb8599d70136fafb8",
     "packages": [
         {
             "name": "apache/avro",
@@ -505,16 +505,16 @@
         },
         {
             "name": "durable-workflow/sdk",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/durable-workflow/sdk-php.git",
-                "reference": "af7931e79683adf55bfa87cd7b3b90561bc137cf"
+                "reference": "865c28b2761b716972604c9adc81dc7e28dbb3cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/durable-workflow/sdk-php/zipball/af7931e79683adf55bfa87cd7b3b90561bc137cf",
-                "reference": "af7931e79683adf55bfa87cd7b3b90561bc137cf",
+                "url": "https://api.github.com/repos/durable-workflow/sdk-php/zipball/865c28b2761b716972604c9adc81dc7e28dbb3cc",
+                "reference": "865c28b2761b716972604c9adc81dc7e28dbb3cc",
                 "shasum": ""
             },
             "require": {
@@ -555,7 +555,7 @@
                         "laravel": "^9.0|^10.0|^11.0|^12.0|^13.0",
                         "symfony": "^6.4|^7.0|^8.0"
                     },
-                    "product-train": "2.0.0",
+                    "product-train": "2.0.1",
                     "payload-codecs": [
                         "avro"
                     ],
@@ -583,7 +583,7 @@
                         "deprecatePatch"
                     ],
                     "worker-protocol-version": "1.19",
-                    "supported-server-versions": "2.0.0",
+                    "supported-server-versions": "2.1.0",
                     "version-marker-history-event": "VersionMarkerRecorded",
                     "message-streams-minimum-worker-protocol-version": "1.15",
                     "durable-selection-minimum-worker-protocol-version": "1.19"
@@ -603,12 +603,16 @@
                     "name": "Durable Workflow Contributors"
                 }
             ],
-            "description": "Framework-neutral PHP client and worker SDK for the Durable Workflow server",
-            "homepage": "https://durable-workflow.com",
+            "description": "PHP client and worker SDK for Durable Workflow Cloud and self-hosted Server",
+            "homepage": "https://php.durable-workflow.com/",
             "keywords": [
+                "cloud",
                 "durable",
+                "laravel",
                 "orchestration",
+                "php",
                 "sdk",
+                "symfony",
                 "worker",
                 "workflow"
             ],
@@ -617,7 +621,7 @@
                 "issues": "https://github.com/durable-workflow/sdk-php/issues",
                 "source": "https://github.com/durable-workflow/sdk-php"
             },
-            "time": "2026-09-01T01:00:27+00:00"
+            "time": "2026-09-03T17:06:51+00:00"
         },
         {
             "name": "egulias/email-validator",

--- a/tests/Feature/ServerIntegrationTest.php
+++ b/tests/Feature/ServerIntegrationTest.php
@@ -216,7 +216,7 @@ class ServerIntegrationTest extends TestCase
         $currentSdk = $waterlineManifest['require-dev']['durable-workflow/sdk'] ?? null;
         $this->assertIsString($currentSdk);
         $installedSdk = InstalledVersions::getPrettyVersion('durable-workflow/sdk');
-        $this->assertSame(ServiceModeRequirements::SDK_VERSION, $installedSdk);
+        $this->assertSame(ServiceModeRequirements::SDK_QUALIFIED_VERSION, $installedSdk);
         $this->assertSame($currentSdk, $installedSdk);
         $this->assertGreaterThanOrEqual(
             0,

--- a/tests/Feature/ServiceModeBackendTest.php
+++ b/tests/Feature/ServiceModeBackendTest.php
@@ -34,8 +34,8 @@ final class ServiceModeBackendTest extends TestCase
 
         self::$installedVersions = InstalledVersions::getRawData();
         $planned = self::$installedVersions;
-        $planned['versions']['durable-workflow/sdk']['pretty_version'] = ServiceModeRequirements::SDK_VERSION;
-        $planned['versions']['durable-workflow/sdk']['version'] = '2.0.0.0-RC45';
+        $planned['versions']['durable-workflow/sdk']['pretty_version'] = ServiceModeRequirements::SDK_QUALIFIED_VERSION;
+        $planned['versions']['durable-workflow/sdk']['version'] = '2.0.1.0';
         InstalledVersions::reload($planned);
     }
 

--- a/tests/Unit/InstallationContractTest.php
+++ b/tests/Unit/InstallationContractTest.php
@@ -43,7 +43,8 @@ final class InstallationContractTest extends TestCase
             512,
             JSON_THROW_ON_ERROR,
         );
-        $sdkVersion = $published['versions']['sdk-php'] ?? null;
+        $publishedSdkVersion = $published['versions']['sdk-php'] ?? null;
+        $qualifiedSdkVersion = $manifest['require-dev']['durable-workflow/sdk'] ?? null;
         $workflowVersion = $published['versions']['workflow'] ?? null;
 
         $this->assertSame([
@@ -57,11 +58,16 @@ final class InstallationContractTest extends TestCase
         );
         $this->assertArrayNotHasKey('durable-workflow/sdk', $manifest['require'] ?? []);
         $this->assertArrayNotHasKey('durable-workflow/workflow', $manifest['require'] ?? []);
-        $this->assertSame($sdkVersion, $manifest['require-dev']['durable-workflow/sdk'] ?? null);
+        $this->assertIsString($publishedSdkVersion);
+        $this->assertIsString($qualifiedSdkVersion);
+        $this->assertGreaterThanOrEqual(0, version_compare($qualifiedSdkVersion, $publishedSdkVersion));
         $this->assertSame($workflowVersion, $manifest['require-dev']['durable-workflow/workflow'] ?? null);
         $this->assertArrayHasKey('durable-workflow/sdk', $manifest['suggest'] ?? []);
         $this->assertArrayHasKey('durable-workflow/workflow', $manifest['suggest'] ?? []);
-        $this->assertSame($sdkVersion, \Waterline\Support\ServiceModeRequirements::SDK_VERSION);
+        $this->assertSame(
+            $qualifiedSdkVersion,
+            \Waterline\Support\ServiceModeRequirements::SDK_QUALIFIED_VERSION,
+        );
     }
 
     public function testCurrentCandidateAdvancesWithoutRewritingFirstSupportedCapacityEvidence(): void

--- a/tests/Unit/ServiceModeRequirementsTest.php
+++ b/tests/Unit/ServiceModeRequirementsTest.php
@@ -14,10 +14,21 @@ final class ServiceModeRequirementsTest extends TestCase
     {
         ServiceModeRequirements::assertSdkInstalled(
             static fn (string $class): bool => true,
-            static fn (): string => ServiceModeRequirements::SDK_VERSION,
+            static fn (): string => ServiceModeRequirements::SDK_QUALIFIED_VERSION,
         );
 
         $this->addToAssertionCount(1);
+    }
+
+    public function testServiceModeAcceptsCompatibleStablePhpSdkReleases(): void
+    {
+        foreach (['2.0.0', '2.0.2', '2.1.0', '2.99.99'] as $version) {
+            ServiceModeRequirements::assertSdkInstalled(
+                static fn (string $class): bool => true,
+                static fn (): string => $version,
+            );
+            $this->addToAssertionCount(1);
+        }
     }
 
     public function testServiceModeReportsStableChannelRemediationWhenThePhpSdkIsMissing(): void
@@ -39,16 +50,21 @@ final class ServiceModeRequirementsTest extends TestCase
         }
     }
 
-    public function testServiceModeRejectsAnOlderReleaseWithoutACompatibilityShim(): void
+    public function testServiceModeRejectsPrereleaseAndIncompatiblePhpSdkVersions(): void
     {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage(
-            'Waterline service mode requires durable-workflow/sdk 2.0.0 exactly; installed 2.0.0-rc.54.',
-        );
-
-        ServiceModeRequirements::assertSdkInstalled(
-            static fn (string $class): bool => true,
-            static fn (): string => '2.0.0-rc.54',
-        );
+        foreach (['2.0.0-rc.54', '1.99.0', '3.0.0', '2.0.x-dev', 'invalid'] as $version) {
+            try {
+                ServiceModeRequirements::assertSdkInstalled(
+                    static fn (string $class): bool => true,
+                    static fn (): string => $version,
+                );
+                $this->fail("Incompatible PHP SDK {$version} must be rejected.");
+            } catch (LogicException $exception) {
+                $this->assertStringContainsString(
+                    "requires a stable durable-workflow/sdk release matching ^2.0; installed {$version}",
+                    $exception->getMessage(),
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #108.

Waterline service mode now accepts stable PHP SDK releases in the SemVer-compatible `^2.0` line while retaining PHP SDK `2.0.1` as the exact qualified package and standalone-service baseline. Prereleases, missing packages, invalid versions, and incompatible major versions still fail with actionable guidance.

The release identity checks now permit a candidate dependency patch to advance the current public tuple without rewriting that tuple before publication.

Validated locally:
- focused service-mode and installation tests: 37 tests, 306 assertions
- release-identity tests: 9 tests
- standalone-lock tests: 4 tests
- qualification-policy tests: 15 tests
- release-example tests: 10 tests
- public SDK 2.0.1 lock identity and Composer audit
- public-boundary and diff checks