### PR TITLE
Update stable Waterline product tuple

### DIFF
--- a/release/current-product-tuple.json
+++ b/release/current-product-tuple.json
@@ -1,8 +1,8 @@
 {
     "schema": "durable-workflow.waterline-current-product-tuple/v1",
     "versions": {
-        "waterline": "2.0.1",
+        "waterline": "2.0.2",
         "workflow": "2.0.1",
-        "sdk-php": "2.0.0"
+        "sdk-php": "2.0.1"
     }
 }


### PR DESCRIPTION
Updates the public stable tuple after the Waterline 2.0.2 and PHP SDK 2.0.1 releases.

Validation:
- `php scripts/verify-release-readiness.php`
- `php scripts/verify-release-examples.php`
- exact Packagist package references verified